### PR TITLE
Added #define to create the STB_IMAGE_IMPLEMENTATION

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
+#define STB_IMAGE_IMPLEMENTATION
 #include "stb/stb_image.h"
 
 


### PR DESCRIPTION
main.cpp will fail to compile without creating the implementation before including stb_image.h